### PR TITLE
Add minimal userland shell

### DIFF
--- a/x64BareBones/Image/Makefile
+++ b/x64BareBones/Image/Makefile
@@ -8,7 +8,7 @@ VMDK=$(OSIMAGENAME).vmdk
 QCOW2=$(OSIMAGENAME).qcow2
 IMG=$(OSIMAGENAME).img
 KERNEL=../Kernel/kernel.bin
-USERLAND=../Userland/0000-sampleCodeModule.bin ../Userland/0001-sampleDataModule.bin
+USERLAND=../Userland/0000-sampleCodeModule.bin ../Userland/0001-sampleDataModule.bin ../Userland/0002-shell.bin
 
 PACKEDKERNEL=packedKernel.bin
 IMGSIZE=6291456

--- a/x64BareBones/Userland/Makefile
+++ b/x64BareBones/Userland/Makefile
@@ -2,7 +2,7 @@ include Makefile.inc
 
 SAMPLE_DATA=0001-sampleDataModule.bin
 
-all: sampleCodeModule sampleDataModule
+all: sampleCodeModule sampleDataModule shell
 
 sampleCodeModule:
 	cd SampleCodeModule; make
@@ -10,9 +10,12 @@ sampleCodeModule:
 sampleDataModule:
 	printf "This is sample data." >> $(SAMPLE_DATA) && dd if=/dev/zero bs=1 count=1 >> $(SAMPLE_DATA)
 
+shell:
+	cd Shell; make
+
 clean:
 	cd SampleCodeModule; make clean
+	cd Shell; make clean
 	rm -rf *.bin
 
-
-.PHONY: sampleCodeModule all clean
+.PHONY: sampleCodeModule sampleDataModule shell all clean

--- a/x64BareBones/Userland/Shell/Makefile
+++ b/x64BareBones/Userland/Shell/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.inc
+
+MODULE=0002-shell.bin
+SOURCES=$(wildcard [^_]*.c)
+
+all: $(MODULE)
+
+$(MODULE): $(SOURCES)
+	$(GCC) $(GCCFLAGS) -I../include -T shell.ld _loader.c $(SOURCES) -o ../$(MODULE)
+
+clean:
+	rm -rf *.o
+
+.PHONY: all clean

--- a/x64BareBones/Userland/Shell/_loader.c
+++ b/x64BareBones/Userland/Shell/_loader.c
@@ -1,0 +1,28 @@
+/* _loader.c */
+#include <stdint.h>
+
+extern char bss;
+extern char endOfBinary;
+
+int main();
+
+void * memset(void * destiny, int32_t c, uint64_t length);
+
+int _start() {
+	//Clean BSS
+	memset(&bss, 0, &endOfBinary - &bss);
+
+	return main();
+
+}
+
+
+void * memset(void * destiation, int32_t c, uint64_t length) {
+	uint8_t chr = (uint8_t)c;
+	char * dst = (char*)destiation;
+
+	while(length--)
+		dst[length] = chr;
+
+	return destiation;
+}

--- a/x64BareBones/Userland/Shell/shell.c
+++ b/x64BareBones/Userland/Shell/shell.c
@@ -1,0 +1,108 @@
+#include "shell.h"
+#include <stdint.h>
+#include <syscall.h>
+
+static int str_eq(const char *a, const char *b) {
+    int i = 0;
+    while (a[i] && b[i] && a[i] == b[i])
+        i++;
+    return a[i] == b[i];
+}
+
+static void print(const char *str) {
+    for (int i = 0; str[i]; i++)
+        syscall_write(str[i]);
+}
+
+void shell_print_help() {
+    print("Available commands:\n");
+    print("help - show this help\n");
+    print("divzero - trigger division by zero\n");
+    print("invopcode - trigger invalid opcode\n");
+    print("time - display system time\n");
+    print("regs - display CPU registers\n");
+    print("clear - clear screen\n");
+}
+
+static int read_line(char *buf, int max) {
+    int i = 0;
+    while (i < max - 1) {
+        char c = syscall_read();
+        if (c == '\n') {
+            break;
+        } else if (c == '\b') {
+            if (i > 0) i--;
+        } else {
+            buf[i++] = c;
+        }
+    }
+    buf[i] = 0;
+    return i;
+}
+
+static void trigger_divzero() {
+    volatile int a = 1 / 0;
+    (void)a;
+}
+
+static void trigger_invopcode() {
+    __asm__ __volatile__("ud2");
+}
+
+static void print_time() {
+    int h, m, s;
+    syscall_get_time(&h, &m, &s);
+    char buf[9];
+    buf[2] = ':'; buf[5] = ':'; buf[8] = 0;
+    buf[0] = '0' + (h / 10); buf[1] = '0' + (h % 10);
+    buf[3] = '0' + (m / 10); buf[4] = '0' + (m % 10);
+    buf[6] = '0' + (s / 10); buf[7] = '0' + (s % 10);
+    print(buf); print("\n");
+}
+
+static void print_regs() {
+    unsigned long regs[17];
+    syscall_get_regs(regs);
+    for(int i=0;i<17;i++) {
+        unsigned long val = regs[i];
+        char hex[17];
+        for(int j=15;j>=0;j--) {
+            int digit = val & 0xF;
+            hex[j] = digit < 10 ? '0'+digit : 'A'+digit-10;
+            val >>= 4;
+        }
+        hex[16] = 0;
+        print("0x");
+        for(int j=0;j<16;j++) syscall_write(hex[j]);
+        print("\n");
+    }
+}
+
+void shell_run() {
+    char line[64];
+    while (1) {
+        print("$> ");
+        read_line(line, sizeof(line));
+        if (line[0] == 0) continue;
+        if (str_eq(line, "help")) {
+            shell_print_help();
+        } else if (str_eq(line, "divzero")) {
+            trigger_divzero();
+        } else if (str_eq(line, "invopcode")) {
+            trigger_invopcode();
+        } else if (str_eq(line, "time")) {
+            print_time();
+        } else if (str_eq(line, "regs")) {
+            print_regs();
+        } else if (str_eq(line, "clear")) {
+            syscall_clear_screen();
+        } else {
+            print("Unknown command\n");
+        }
+    }
+}
+
+int main() {
+    shell_run();
+    return 0;
+}

--- a/x64BareBones/Userland/Shell/shell.h
+++ b/x64BareBones/Userland/Shell/shell.h
@@ -1,0 +1,7 @@
+#ifndef SHELL_H
+#define SHELL_H
+
+void shell_run();
+void shell_print_help();
+
+#endif // SHELL_H

--- a/x64BareBones/Userland/Shell/shell.ld
+++ b/x64BareBones/Userland/Shell/shell.ld
@@ -1,0 +1,21 @@
+OUTPUT_FORMAT("binary")
+ENTRY(_start)
+SECTIONS
+{
+	.text 0x400000 :
+	{
+		*(.text*)
+		. = ALIGN(0x1000);
+		*(.rodata*)
+	}
+	.data ALIGN(0x1000) :
+	{
+		*(.data*)
+	}
+	.bss ALIGN(0x1000) :
+	{
+		bss = .;
+		*(.bss*)
+	}
+	endOfBinary = .;
+}

--- a/x64BareBones/Userland/include/syscall.h
+++ b/x64BareBones/Userland/include/syscall.h
@@ -1,0 +1,30 @@
+#ifndef SYSCALL_H
+#define SYSCALL_H
+
+static inline void syscall_write(char c) {
+    __asm__ __volatile__("int $0x80" : : "a"(1), "b"(c));
+}
+
+static inline char syscall_read() {
+    char c;
+    __asm__ __volatile__("int $0x80" : "=a"(c) : "a"(0));
+    return c;
+}
+
+static inline void syscall_clear_screen() {
+    __asm__ __volatile__("int $0x80" : : "a"(2));
+}
+
+static inline void syscall_get_time(int *hours, int *mins, int *secs) {
+    int h, m, s;
+    __asm__ __volatile__("int $0x80" : "=a"(h), "=b"(m), "=c"(s) : "a"(3));
+    if(hours) *hours = h;
+    if(mins) *mins = m;
+    if(secs) *secs = s;
+}
+
+static inline void syscall_get_regs(unsigned long *regs) {
+    __asm__ __volatile__("int $0x80" : : "a"(4), "b"(regs));
+}
+
+#endif // SYSCALL_H


### PR DESCRIPTION
## Summary
- add basic syscall wrappers for userland
- implement a simple shell with commands for help, time, regs and exceptions
- add build rules for the shell binary and include it in the image

## Testing
- `make clean` *(fails: ModulePacker not found)*
- `make` *(fails: ModulePacker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fca274808320a99a552108d5aee8