### PR TITLE
Implement stable exception return for hobby OS

### DIFF
--- a/x64BareBones/Kernel/include/defs.h
+++ b/x64BareBones/Kernel/include/defs.h
@@ -5,7 +5,6 @@
 #ifndef _defs_
 #define _defs_
 
-
 /* Flags para derechos de acceso de los segmentos */
 #define ACS_PRESENT     0x80            /* segmento presente en memoria */
 #define ACS_CSEG        0x18            /* segmento de codigo */
@@ -13,13 +12,13 @@
 #define ACS_READ        0x02            /* segmento de lectura */
 #define ACS_WRITE       0x02            /* segmento de escritura */
 #define ACS_IDT         ACS_DSEG
-#define ACS_INT_386 	0x0E		/* Interrupt GATE 32 bits */
+#define ACS_INT_386     0x0E            /* Interrupt GATE 32 bits */
 #define ACS_INT         ( ACS_PRESENT | ACS_INT_386 )
-
+#define ACS_TRAP_386    0x0F            /* Trap GATE 32 bits */
+#define ACS_TRAP        ( ACS_PRESENT | ACS_TRAP_386 )
 
 #define ACS_CODE        (ACS_PRESENT | ACS_CSEG | ACS_READ)
 #define ACS_DATA        (ACS_PRESENT | ACS_DSEG | ACS_WRITE)
 #define ACS_STACK       (ACS_PRESENT | ACS_DSEG | ACS_WRITE)
-
 
 #endif

--- a/x64BareBones/Kernel/include/idtLoader.h
+++ b/x64BareBones/Kernel/include/idtLoader.h
@@ -9,7 +9,7 @@
 // DECLARACIÓN DE PROTOTIPOS
 //******************************************************************************
 
-static void setup_IDT_entry(int index, uint64_t offset);
+static void setup_IDT_entry(int index, uint64_t offset, uint8_t access);
 void load_idt();
 
 

--- a/x64BareBones/Kernel/src/idtLoader.c
+++ b/x64BareBones/Kernel/src/idtLoader.c
@@ -19,16 +19,16 @@ typedef struct {
 
 DESCR_INT * idt = (DESCR_INT *) 0;	// IDT de 255 entradas
 
-static void setup_IDT_entry (int index, uint64_t offset);
+static void setup_IDT_entry (int index, uint64_t offset, uint8_t access);
 
 void load_idt() {
 
-  setup_IDT_entry (0x20, (uint64_t)&_irq00Handler);
-  setup_IDT_entry (0x00, (uint64_t)&_exception0Handler);
+  setup_IDT_entry (0x20, (uint64_t)&_irq00Handler, ACS_INT);
+  setup_IDT_entry (0x00, (uint64_t)&_exception0Handler, ACS_TRAP);
 
-  setup_IDT_entry(0x21, (uint64_t)&_irq01Handler); // Teclado
+  setup_IDT_entry(0x21, (uint64_t)&_irq01Handler, ACS_INT); // Teclado
 
-  setup_IDT_entry(0x80, (uint64_t)&_int80Handler);
+  setup_IDT_entry(0x80, (uint64_t)&_int80Handler, ACS_INT);
 
   picMasterMask(0xFC); //Habilita IRQ0 y IRQ1 (timer y teclado)
 	picSlaveMask(0xFF);
@@ -36,12 +36,12 @@ void load_idt() {
 	_sti();
 }
 
-static void setup_IDT_entry (int index, uint64_t offset) {
+static void setup_IDT_entry (int index, uint64_t offset, uint8_t access) {
   idt[index].selector = 0x08;
   idt[index].offset_l = offset & 0xFFFF;
   idt[index].offset_m = (offset >> 16) & 0xFFFF;
   idt[index].offset_h = (offset >> 32) & 0xFFFFFFFF;
-  idt[index].access = ACS_INT;
+  idt[index].access = access;
   idt[index].cero = 0;
   idt[index].other_cero = (uint64_t) 0;
 }


### PR DESCRIPTION
## Summary
- rework `exceptionHandler` macro to restore user stack and enable IF
- add trap gate attributes
- allow IDT entries with custom attributes
- install exception 0 as a trap gate

## Testing
- `make` *(fails: ModulePacker/mp.bin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed231db48320b00e9d2fc97c77cf